### PR TITLE
Permission check

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -13,7 +13,7 @@
   "eqnull": true,
   "node": true,
   "quotmark": "single",
-
+  "multistr": true,
   "globals": {
     "after": false,
     "before": false,

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var fs = require('fs'),
-    path = require('path'),
-    Q = require('q');
+  path = require('path'),
+  Q = require('q');
 
 var lib = require('manifoldjs-lib'),
-    CustomError = lib.CustomError;
+  CustomError = lib.CustomError;
 
 var localize = require('./localize');
 
@@ -35,44 +35,48 @@ function isValidIconFormat(icon, validFormats) {
 }
 
 function capabilitiesString(extManifest) {
-  // Map extension permissions to app capabilities
-  var capabilitiesMap = {
-    '<any url>': 'websiteContent',
-    '<all_urls>': 'websiteContent',
-    'cookies': 'websiteCookies',
-    'geolocation': 'geolocation',
-    'storage': 'browserStorage',
-    'tabs': 'websiteInfo',
-    'webNavigation': 'websiteInfo',
-    'webRequest': 'browserWebRequest'
-  };
+  if (extManifest.permissions === undefined || extManifest.permissions === null) {
+    return '';
+  } else {
+    // Map extension permissions to app capabilities
+    var capabilitiesMap = {
+      '<any url>': 'websiteContent',
+      '<all_urls>': 'websiteContent',
+      'cookies': 'websiteCookies',
+      'geolocation': 'geolocation',
+      'storage': 'browserStorage',
+      'tabs': 'websiteInfo',
+      'webNavigation': 'websiteInfo',
+      'webRequest': 'browserWebRequest'
+    };
 
-  var capabilities = {};
-  for (var index = 0; index < extManifest.permissions.length; index++) {
-    var element = extManifest.permissions[index];
+    var capabilities = {};
+    for (var index = 0; index < extManifest.permissions.length; index++) {
+      var element = extManifest.permissions[index];
 
-    if (capabilitiesMap.hasOwnProperty(element)) {
-      capabilities[capabilitiesMap[element]] = true;
-    }
-
-    if (element.indexOf('://') > 0) {
-      capabilities['websiteContent'] = true;
-    }
-  }
-
-  var capCount = Object.keys(capabilities).length;
-  var capString = '';
-  for (var key in capabilities) {
-    if (capabilities.hasOwnProperty(key)) {
-      capString += '<Capability Name="' + key + '"/>';
-      if (capCount > 1) {
-        capString += '\r\n\t\t\t\t\t\t\t\t';
+      if (capabilitiesMap.hasOwnProperty(element)) {
+        capabilities[capabilitiesMap[element]] = true;
       }
-      capCount--;
-    }
-  }
 
-  return capString;
+      if (element.indexOf('://') > 0) {
+        capabilities['websiteContent'] = true;
+      }
+    }
+
+    var capCount = Object.keys(capabilities).length;
+    var capString = '';
+    for (var key in capabilities) {
+      if (capabilities.hasOwnProperty(key)) {
+        capString += '<Capability Name="' + key + '"/>';
+        if (capCount > 1) {
+          capString += '\r\n\t\t\t\t\t\t\t\t';
+        }
+        capCount--;
+      }
+    }
+
+    return capString;
+  }
 }
 
 function getExtensionVersion(extManifest) {
@@ -159,10 +163,10 @@ function convertFromBase(manifestInfo, extensionLocalesList, callback) {
 
     return convertedManifestInfo;
   })
-  .catch(function (err) {
-    return Q.reject(new CustomError('Could not read the manifest template', err));
-  })
-  .nodeify(callback);
+    .catch(function (err) {
+      return Q.reject(new CustomError('Could not read the manifest template', err));
+    })
+    .nodeify(callback);
 }
 
 module.exports = {

--- a/lib/validationRules/permissionsNotRequired.js
+++ b/lib/validationRules/permissionsNotRequired.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var manifest = require('../../lib/manifest');
+
+module.exports = function (manifestContent, callback) {
+    var content = '<?xml version="1.0" encoding="utf-8"?> \
+<Package \
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" \
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" \
+  xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" \
+  IgnorableNamespaces="uap3"> \
+  \
+  <Identity \
+    Name="[REPLACE WITH PACKAGE/IDENTITYNAME]" \
+    Publisher="[REPLACE WITH PACKAGE/IDENTITY/PUBLISHER]" \
+    Version="[REPLACE WITH PACKAGE VERSION in the form X.X.X.0]"/> \
+\
+  <Properties> \
+    <DisplayName>[REPLACE WITH RESERVED STORE NAME]</DisplayName> \
+    <PublisherDisplayName>[REPLACE WITH PACKAGE/PROPERTIES/PUBLISHERDISPLAYNAME]</PublisherDisplayName> \
+    <Logo>[REPLACE WITH RELATIVE PATH TO 50x50 ICON]</Logo> \
+  </Properties> \
+\
+  <Dependencies> \
+    <TargetDeviceFamily Name="Windows.Desktop" \
+      MinVersion="10.0.14393.0" \
+      MaxVersionTested="10.0.14800.0" /> \
+  </Dependencies> \
+\
+  <Resources> \
+    <Resource Language="en-us"/> \
+  </Resources> \
+\
+  <Applications> \
+    <Application Id="App"> \
+      <uap:VisualElements  \
+        AppListEntry="none" \
+        DisplayName="[REPLACE WITH RESERVED STORE NAME]" \
+        Square150x150Logo="[REPLACE WITH RELATIVE PATH TO 150x150 ICON]" \
+        Square44x44Logo="[REPLACE WITH RELATIVE PATH TO 44x44 ICON]" \
+        Description="This is the description of the extension" \
+        BackgroundColor="white"> \
+      </uap:VisualElements> \
+      <Extensions> \
+      <uap3:Extension Category="windows.appExtension"> \
+        <uap3:AppExtension Name="com.microsoft.edge.extension" \
+          Id="EdgeExtension" \
+          PublicFolder="Extension" \
+          DisplayName="[REPLACE WITH RESERVED STORE NAME]"> \
+        </uap3:AppExtension> \
+      </uap3:Extension> \
+      </Extensions> \
+ </Application> \
+</Applications> \
+</Package>';
+    var locales = 'en-us';
+
+    try {
+        manifest.replaceManifestValues(manifestContent, content, locales);
+        callback(undefined, undefined);
+    } catch (e) {
+        callback(e, undefined);
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manifoldjs-edgeextension",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "ManifoldJS Microsoft Edge Extension Platform",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manifoldjs-edgeextension",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "ManifoldJS Microsoft Edge Extension Platform",
   "repository": {
     "type": "git",
@@ -33,7 +33,7 @@
     "ManifoldJS",
     "Edge Extension"
   ],
-  "dependencies": {    
+  "dependencies": {
     "q": "^1.4.1",
     "archiver": "^0.20.0",
     "cloudappx-server": "^0.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manifoldjs-edgeextension",
-  "version": "0.1.9",
+  "version": "0.1.8",
   "description": "ManifoldJS Microsoft Edge Extension Platform",
   "repository": {
     "type": "git",

--- a/test/validations/permissionsNotRequired.js
+++ b/test/validations/permissionsNotRequired.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var should = require('should');
+
+var validation = require('../../lib/validationRules/permissionsNotRequired');
+
+
+describe('Validation - Permissions property not required', function () {
+    describe('permissionsNotRequired', function () {
+        it('Should not error when a manifest does not contain permissions.', function (done) {
+
+            var manifestWithoutPermissions = { manifest_version: 2, version: '1.0.0.0', name: 'Test', description: 'test manifest' };
+
+            validation(manifestWithoutPermissions, function (err, warning) {
+                should.not.exist(err);
+                should.not.exist(warning);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
#13 I made an attempt to fix the error I encountered. If the "permissions" property is not present on the manifest then the capability string returns empty rather than attempting to loop through.
I tried my hand at adding to the unit tests to cover this case - I've not really worked with this JS testing before (only MSTest) but I gave it a go. The test fails without my code and passes after the change.

I made a mistake in doubly incrementing the version, which is why there is a second commit and reversion. It's only incremented once in total, by a patch.